### PR TITLE
Reloading fix with webpack-serve

### DIFF
--- a/serve.config.js
+++ b/serve.config.js
@@ -4,4 +4,5 @@ module.exports = {
   clipboard: false,
   content: [path.resolve(__dirname, 'desktop')],
   port: 8082,
+  dev: { publicPath: '/dist' }
 }


### PR DESCRIPTION
Without the following fix, webpack-dev-middleware calculates the
wrong path for the bundle, and serves a 404.

The demo was still working because there was a static bundle saved
in desktop/dist already, but it wouldn't update.